### PR TITLE
fix: Keep retrocompatibility with Go 1.11 and earlier

### DIFF
--- a/item.go
+++ b/item.go
@@ -28,7 +28,7 @@ type jsonItem struct {
 
 func transformKey(k string) string {
 	k = strings.ToLower(k)
-	k = strings.ReplaceAll(k, "_", "-")
+	k = strings.Replace(k, "_", "-", -1)
 	return k
 }
 


### PR DESCRIPTION
Closing #17

Signed-off-by: Romain Beuque <romain.beuque@corp.ovh.com>