### PR TITLE
providers: notify watchers when a new provider is added to a store

### DIFF
--- a/configstore_test.go
+++ b/configstore_test.go
@@ -179,6 +179,25 @@ func TestStore(t *testing.T) {
 	assert.Equal(mustType(err, ErrAmbiguousItem("")), false)
 }
 
+func TestStoreWatch(t *testing.T) {
+	s := NewStore()
+	s.RegisterProvider("test", ProviderTest2)
+	assert := assert.New(t)
+	ch := s.Watch()
+	select {
+	case <-ch:
+		assert.FailNow("already a dangling message in watcher")
+	default:
+	}
+
+	s.RegisterProvider("test3", ProviderTest2)
+	select {
+	case <-ch:
+	default:
+		assert.FailNow("no notifications has been sent")
+	}
+}
+
 func mustValue(i Item) string {
 	v, err := i.Value()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/ovh/configstore
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -10,7 +9,7 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/store.go
+++ b/store.go
@@ -74,6 +74,7 @@ func (s *Store) RegisterProvider(name string, f Provider) {
 	}
 	s.pMut.Lock()
 	defer s.pMut.Unlock()
+	defer s.NotifyWatchers()
 	_, ok := s.providers[name]
 	if ok && !s.allowProviderOverride {
 		s.providers[ProviderConflictErrorLabel] = newErrorProvider(fmt.Errorf("configstore: conflict on configuration provider: %s", name))


### PR DESCRIPTION
When a new provider is added, we should notify all watchers, as the data returned by a filter could be different.