### PR TITLE
fix: use UnmarshalJSON when reading a file

### DIFF
--- a/item.go
+++ b/item.go
@@ -2,6 +2,7 @@ package configstore
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -38,10 +39,13 @@ func NewItem(key, value string, priority int64) Item {
 	return Item{key: transformKey(key), value: value, priority: priority}
 }
 
-// UnmarshalJSON respects json.Unmarshaler
+// UnmarshalJSON respects json.Unmarshaler.
+//
+// Even in the inital payload is in YAML, goccy convert it to JSON before calling
+// this method so we have to use json.Unmarshal here.
 func (s *Item) UnmarshalJSON(b []byte) error {
 	j := &jsonItem{}
-	err := yaml.Unmarshal(b, &j)
+	err := json.Unmarshal(b, &j)
 	if err != nil {
 		return err
 	}

--- a/provider_file_test.go
+++ b/provider_file_test.go
@@ -1,0 +1,52 @@
+package configstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileProviderYAML(t *testing.T) {
+	var s = NewStore()
+	s.File("tests/fixtures/fileprovider/test.yaml")
+	l, err := s.GetItemList()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, l.Len())
+
+	for _, i := range l.Items {
+		t.Logf("items: %s - %s", i.key, i.value)
+	}
+
+	i, has := l.indexed["my-config-key-1"]
+	require.True(t, has, "missing 'my-config-key-1' items")
+	require.Len(t, i, 1, "there must be 1 'my-config-key-1' item")
+
+	i, has = l.indexed["my-config-key-2"]
+	require.True(t, has, "missing 'my-config-key-2' items")
+	require.Len(t, i, 1, "there must be 1 'my-config-key-2' item")
+
+}
+
+func TestFileProviderJSON(t *testing.T) {
+	var s = NewStore()
+	s.File("tests/fixtures/fileprovider/test.json")
+	l, err := s.GetItemList()
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, l.Len())
+
+	for _, i := range l.Items {
+		t.Logf("items: %s - %s", i.key, i.value)
+	}
+
+	i, has := l.indexed["my-config-key-1"]
+	require.True(t, has, "missing 'my-config-key-1' items")
+	require.Len(t, i, 1, "there must be 1 'my-config-key-1' item")
+
+	i, has = l.indexed["my-config-key-2"]
+	require.True(t, has, "missing 'my-config-key-2' items")
+	require.Len(t, i, 1, "there must be 1 'my-config-key-2' item")
+
+}

--- a/providers.go
+++ b/providers.go
@@ -177,7 +177,7 @@ func readFile(filename string, fn func([]byte) ([]Item, error)) ([]Item, error) 
 	if fn != nil {
 		return fn(b)
 	}
-	err = yaml.Unmarshal(b, &vals)
+	err = yaml.UnmarshalWithOptions(b, &vals, yaml.UseJSONUnmarshaler())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/fixtures/fileprovider/test.json
+++ b/tests/fixtures/fileprovider/test.json
@@ -1,0 +1,10 @@
+[
+  {
+    "key": "my-config-key-1",
+    "value": "my-value-1"
+  },
+  {
+    "key": "my-config-key-2",
+    "value": "my-value-2"
+  }
+]

--- a/tests/fixtures/fileprovider/test.yaml
+++ b/tests/fixtures/fileprovider/test.yaml
@@ -1,0 +1,5 @@
+- key: my-config-key-1
+  value: my-value-1
+
+- key: my-config-key-2
+  value: my-value-2


### PR DESCRIPTION
Fix a bug introduced in #36 that breaks the file provider.

The `goccy/go-yaml` docs says:
> Struct fields are only unmarshalled if they are exported (have an upper case first letter)

(https://github.com/goccy/go-yaml/blob/25e5d9094248e480434ca87d9119e3d9ce7ac1d7/yaml.go#L175)

But in case of YAMLs, the `Item` struct is directly used and has unexported fields:
https://github.com/ovh/configstore/blob/b6a9d43fb48339c37f5fdc4172e695745260e43d/item.go#L14-L20

And `goccy/go-yaml` is not calling the `UnmarshallJSON` method unless configured to do so.


I've added a quick unit test to cover this.